### PR TITLE
Fix for 'fatal error' when modulePattern matches nothing

### DIFF
--- a/tasks/blanket_mocha.js
+++ b/tasks/blanket_mocha.js
@@ -121,7 +121,9 @@ module.exports = function(grunt) {
             totals.coveredLines += coveredLines;
 
             if (modulePatternRegex) {
-                var moduleName = filename.match(modulePatternRegex)[1];
+                var match = filename.match(modulePatternRegex);
+				if (!match) return;
+                var moduleName = match[1];
                 if(!totals.moduleTotalStatements.hasOwnProperty(moduleName)) {
                     totals.moduleTotalStatements[moduleName] = 0;
                     totals.moduleTotalCoveredStatements[moduleName] = 0;


### PR DESCRIPTION
This error happens when 'modulePattern' is specified, but doesn't match anything. Grunt dies with mysterious message:  'fatal error, cannot read property 1 of null'

this is a very simple change, but it took many hours to find - I was very new to coverage (and it is saddening how much time it ate), hopefully this will not create problems to others...